### PR TITLE
Added a synthetic ID to features without an ID when creating topojson from geojson to prevent loss of feature(s). Fixes #2

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -1,12 +1,20 @@
 package topojson
 
-import "github.com/paulmach/go.geojson"
+import (
+	"github.com/paulmach/go.geojson"
+	"fmt"
+)
 
 func (t *Topology) extract() {
 	t.objects = make([]*topologyObject, 0, len(t.input))
 
-	for _, g := range t.input {
-		t.objects = append(t.objects, t.extractFeature(g))
+	for i, g := range t.input {
+		feature := t.extractFeature(g)
+		if len(feature.ID) == 0 {
+			// if multiple features exist without ids only one will be retained, so provide a synthetic id
+			feature.ID = fmt.Sprintf("feature_%d", i)
+		}
+		t.objects = append(t.objects, feature)
 	}
 	t.input = nil // no longer needed
 }

--- a/topology_test.go
+++ b/topology_test.go
@@ -46,3 +46,23 @@ func TestFull(t *testing.T) {
 	is.NoErr(err)
 	is.Equal(topo, expected)
 }
+
+// https://github.com/rubenv/topojson/issues/2
+func TestMultiFeatures(t *testing.T) {
+	is := is.New(t)
+
+	fc := geojson.NewFeatureCollection()
+	f1 := geojson.NewPolygonFeature([][][]float64{
+		{{0, 0}, {1, 1}, {2, 0}, {1, -1}, {0, 0}},
+		{{0.25, 0}, {0.75, -0.25}, {0.75, 0.25}, {0.25, 0}},
+	})
+	fc.AddFeature(f1)
+	f2 := geojson.NewPolygonFeature([][][]float64{
+		{{0, 0}, {1, 1}, {2, 0}, {1, 2}, {0, 0}},
+	})
+	fc.AddFeature(f2)
+
+	topo := NewTopology(fc, nil)
+
+	is.Equal(len(topo.Objects), len(fc.Features))
+}


### PR DESCRIPTION
The javascript library always creates a single GeometryCollection containing the geometries of all features in the collection. This causes information (properties of the features) to be lost, so I took the approach of creating a synthetic id instead.